### PR TITLE
ddl: fix multi-schema change success when sub-job failed

### DIFF
--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -813,7 +813,6 @@ func TestMultiSchemaChangeModifyColumns(t *testing.T) {
 	tk.MustExec("admin check table t;")
 	checkDelRangeCnt(tk, jobIDExt.jobID, 1) // only i2 has tmp index.
 
-	// issue link: https://github.com/tangenta/tidb/issues/74
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a bigint null default '1761233443433596323', index t(a));")
 	tk.MustExec("insert into t set a = '-7184819032643664798';")

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -812,6 +812,12 @@ func TestMultiSchemaChangeModifyColumns(t *testing.T) {
 	tk.MustQuery("select * from t use index(i1, i2);").Check(testkit.Rows("1 3 2", "11 33 22"))
 	tk.MustExec("admin check table t;")
 	checkDelRangeCnt(tk, jobIDExt.jobID, 1) // only i2 has tmp index.
+
+	// issue link: https://github.com/tangenta/tidb/issues/74
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t(a bigint null default '1761233443433596323', index t(a));")
+	tk.MustExec("insert into t set a = '-7184819032643664798';")
+	tk.MustGetErrCode("alter table t change column a b datetime null default '8972-12-24 10:56:03', rename index t to t1;", errno.ErrTruncatedWrongValue)
 }
 
 func TestMultiSchemaChangeModifyColumnsCancelled(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #74

Problem Summary: `ReorgMeta` don't set in multi-schema change job which will cause SQL Mode equals to nil and ignore errors when data truncated in column modify.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
