### PR TITLE
ddl: rollback multi-schema-change job when transfer to non-revertible failed

### DIFF
--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -842,6 +842,15 @@ func TestMultiSchemaChangeModifyColumns(t *testing.T) {
 	require.Equal(t, rows[0][11], "rollback done")
 	require.Equal(t, rows[1][11], "rollback done")
 	require.Equal(t, rows[2][11], "cancelled")
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t(a int, b int);")
+	jobIDExt = wrapJobIDExtCallback(originHook)
+	dom.DDL().SetHook(jobIDExt)
+	tk.MustExec("insert into t values (1, 2);")
+	tk.MustGetErrCode("alter table t add index i(a), modify column a int null default 1 after a;", errno.ErrBadField)
+	checkDelRangeCnt(tk, jobIDExt.jobID, 1)
+
 }
 
 func TestMultiSchemaChangeModifyColumnsCancelled(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #90

Problem Summary:

When multi-schema-change job change status from revertable to non-revertable we also should check the error message and rollback it when job failed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
