### PR TITLE
ddl: not allowed modify a column covered by expression index or generate column

### DIFF
--- a/ddl/multi_schema_change.go
+++ b/ddl/multi_schema_change.go
@@ -192,6 +192,10 @@ func handleRevertibleException(job *model.Job, subJob *model.SubJob, err *terror
 	// Flush the cancelling state and cancelled state to sub-jobs.
 	for _, sub := range job.MultiSchemaInfo.SubJobs {
 		switch sub.State {
+		case model.JobStateCancelled:
+			if !sub.Revertible {
+				sub.State = model.JobStateCancelling
+			}
 		case model.JobStateRunning:
 			sub.State = model.JobStateCancelling
 		case model.JobStateNone, model.JobStateQueueing:

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -268,6 +268,7 @@ type MultiSchemaInfo struct {
 	AlterIndexes  []CIStr `json:"-"`
 
 	RelativeColumns []CIStr `json:"-"`
+	PositionColumns []CIStr `json:"-"`
 }
 
 func NewMultiSchemaInfo() *MultiSchemaInfo {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #112, close #111

Problem Summary:

```
not allowed modify a column covered by expression index or generate column
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
